### PR TITLE
Support named logging contexts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- AWS Lambda sentinel check
 - Packaging metadata to reflect the move under Tackle's aegis
+### Added
+
+- Names for logging contexts
 
 ## [v0.3] 30 December, 2021
 

--- a/demo/http_demo/app.py
+++ b/demo/http_demo/app.py
@@ -11,7 +11,7 @@ from woodchipper.http.flask import WoodchipperFlask
 
 os.environ["WOODCHIPPER_KEY_PREFIX"] = "tkl"
 
-woodchipper.configure(config=DevLogToStdout, facilities={"app": "INFO", "werkzeug": "INFO", "flask": "INFO"})
+woodchipper.configure(config=DevLogToStdout, facilities={"": "INFO"})
 
 logger = woodchipper.get_logger(__name__)
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -35,7 +35,8 @@ def test_logging_context_var():
 
 def test_logging_context_prefix():
     assert context.logging_ctx.as_dict() == {}
-    with context.LoggingContext(a=1, _prefix="test"):
+    ctx_obj = context.LoggingContext("test-name", a=1, _prefix="test")
+    with ctx_obj:
         assert context.logging_ctx.as_dict() == {"test.a": 1}
 
     with patch("woodchipper.context.os.getenv", return_value="env"):
@@ -44,3 +45,33 @@ def test_logging_context_prefix():
 
     with context.LoggingContext(a=1, _prefix=None):
         assert context.logging_ctx.as_dict() == {"a": 1}
+
+
+def test_logging_context_name():
+    ctx_obj = context.LoggingContext("test-name", a=1, _prefix="test")
+    with ctx_obj:
+        assert ctx_obj.name == "test-name"
+    assert ctx_obj.name == "test-name"
+
+    ctx_obj = context.LoggingContext(a=1, _prefix="test")
+    with ctx_obj:
+        assert ctx_obj.name is None
+    assert ctx_obj.name == "test_context:test_logging_context_name"
+
+    ctx_obj = context.LoggingContext("test-name", a="x", _prefix="test")
+
+    @ctx_obj
+    def f(x):
+        assert ctx_obj.name == "test-name"
+
+    f(1)
+    assert ctx_obj.name == "test-name"
+
+    ctx_obj = context.LoggingContext(a="x", _prefix="test")
+
+    @ctx_obj
+    def f(x):
+        assert ctx_obj.name == "test_context:f"
+
+    f(1)
+    assert ctx_obj.name == "test_context:f"

--- a/woodchipper/http/awslambda.py
+++ b/woodchipper/http/awslambda.py
@@ -13,6 +13,7 @@ class WoodchipperLambda:
             return self._app(environ, start_response)
         context = environ.get("lambda.context", object())
         with LoggingContext(
+            "awslambda:dispatch",
             **{
                 "aws-request-id": getattr(context, "aws_request_id", None),
                 "function-version": getattr(context, "function_version", None),

--- a/woodchipper/http/flask.py
+++ b/woodchipper/http/flask.py
@@ -18,6 +18,7 @@ class WoodchipperFlask:
         if not getattr(g, "request_id", None):
             g.request_id = self._request_id_factory()
         with LoggingContext(
+            "flask:request",
             **{
                 "id": g.request_id,
                 "body_size": request.content_length,


### PR DESCRIPTION
With this PR, the exit message for a LoggingContext has a name identifying which context it is. The name can be provided as a positional arg to `LoggingContext`, but if not, it is derived from the module and function name from which the context was created.

Example: when exiting the Flask WSGI wrapper context:

```
2022-01-04 20:19.28 [info     ] Exiting context: flask:request [woodchipper.http.flask] context.time_to_run_μsec=39929 func_name=__exit__ http.body_size=None http.header.accept=*/* http.header.host=localhost:5000 http.header.user-agent=curl/7.64.1 http.id=607ba0ad-79a3-401a-aa23-cd77535cdb68 http.method=GET http.url=http://localhost:5000/ lineno=188 module=context
```

Example: when running the context_demo demo script:

```
2022-01-04 20:20.44 [info     ] Decorated.                     [__main__] func_name=decorated_func lineno=19 module=demo tkl.vendor=DEMOVENDOR
2022-01-04 20:20.44 [info     ] Exiting context: __main__.decorated_func [woodchipper.context] context.time_to_run_μsec=6431 func_name=__exit__ lineno=188 module=context tkl.vendor=DEMOVENDOR
2022-01-04 20:20.44 [info     ] Context one.                   [__main__] func_name=ctx_func lineno=24 module=demo tkl.vendor=DEMOVENDOR
2022-01-04 20:20.44 [info     ] Context two.                   [__main__] func_name=ctx_func lineno=26 module=demo tkl.product=DEMOPRODUCT tkl.vendor=DEMOVENDOR
2022-01-04 20:20.44 [info     ] Exiting context: __main__:ctx_func [__main__] context.time_to_run_μsec=273 func_name=__exit__ lineno=188 module=context tkl.product=DEMOPRODUCT tkl.vendor=DEMOVENDOR
2022-01-04 20:20.44 [info     ] Context three.                 [__main__] func_name=ctx_func lineno=27 module=demo tkl.vendor=DEMOVENDOR
2022-01-04 20:20.44 [info     ] Exiting context: __main__:ctx_func [__main__] context.time_to_run_μsec=740 func_name=__exit__ lineno=188 module=context tkl.vendor=DEMOVENDOR
2022-01-04 20:20.44 [info     ] Context four.                  [__main__] func_name=ctx_func lineno=28 module=demo
```