### PR TITLE
Append prefix for all logging contexts.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The environment variable set log key prefix is now appended to all logging context variables.
+
 ## [v0.4] 5 January, 2022
 
 ### Fixed

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,26 @@
+import contextlib
+import io
+import json
+import os
+from unittest.mock import patch
+
+import woodchipper
+import woodchipper.configs
+
+
+def test_bind_log_prefix():
+    with patch.dict(os.environ, dict(WOODCHIPPER_KEY_PREFIX="footest")):
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            woodchipper.configure(config=woodchipper.configs.Minimal, facilities={"": "INFO"})
+            logger = woodchipper.get_logger(__name__)
+            logger.info("Message one.", a=1)
+            logger_with_ctx = logger.bind(**{"b": 2, "customprefix.bar": "baz"})
+            logger_with_ctx.info("Message two.", a=1)
+        messages = [json.loads(message) for message in buf.getvalue().strip().split("\n")]
+        assert messages[0]["event"] == "Message one."
+        assert messages[0]["level"] == "info"
+        assert messages[0]["footest.a"] == 1
+        assert messages[1]["footest.b"] == 2
+        assert messages[1]["customprefix.bar"] == "baz"
+        assert messages[1]["footest.a"] == 1

--- a/woodchipper/configs.py
+++ b/woodchipper/configs.py
@@ -1,5 +1,6 @@
 import structlog
 
+import woodchipper.logger
 import woodchipper.processors
 from woodchipper import BaseConfigClass
 
@@ -19,7 +20,7 @@ class Minimal(BaseConfigClass):
         structlog.stdlib.add_log_level,
     ]
     factory = structlog.stdlib.LoggerFactory()
-    wrapper_class = structlog.stdlib.BoundLogger
+    wrapper_class = woodchipper.logger.BoundLogger
     renderer = structlog.processors.JSONRenderer()
 
 
@@ -37,7 +38,7 @@ class DevLogToStdout(BaseConfigClass):
         woodchipper.processors.inject_context_processor,
     ]
     factory = structlog.stdlib.LoggerFactory()
-    wrapper_class = structlog.stdlib.BoundLogger
+    wrapper_class = woodchipper.logger.BoundLogger
     renderer = structlog.dev.ConsoleRenderer()
 
 
@@ -56,5 +57,5 @@ class JSONLogToStdout(BaseConfigClass):
         woodchipper.processors.inject_context_processor,
     ]
     factory = structlog.stdlib.LoggerFactory()
-    wrapper_class = structlog.stdlib.BoundLogger
+    wrapper_class = woodchipper.logger.BoundLogger
     renderer = structlog.processors.JSONRenderer()

--- a/woodchipper/logger.py
+++ b/woodchipper/logger.py
@@ -1,0 +1,37 @@
+import os
+from typing import Any, Mapping, Optional, Sequence
+
+from structlog.stdlib import BoundLogger as StdlibBoundLogger
+
+NO_PREFIX_LIST = ["exc_info"]
+
+
+class BoundLogger(StdlibBoundLogger):
+    def prefix_kwargs(self, **kwargs: Any) -> Mapping[str, Any]:
+        prefix = os.getenv("WOODCHIPPER_KEY_PREFIX")
+        if not prefix:
+            return kwargs
+        prefixed_kw = {}
+        for key, value in kwargs.items():
+            prefixed_kw[key if "." in key or key in NO_PREFIX_LIST else f"{prefix}.{key}"] = value
+        return prefixed_kw
+
+    def prefix_keys(self, *keys: str) -> Sequence[str]:
+        prefix = os.getenv("WOODCHIPPER_KEY_PREFIX")
+        if not prefix:
+            return keys
+        return [key if "." in key or key in NO_PREFIX_LIST else f"{prefix}.{key}" for key in keys]
+
+    def bind(self, **new_values: Any) -> "BoundLogger":
+        return super().bind(**self.prefix_kwargs(**new_values))  # type: ignore
+
+    def unbind(self, *keys: str) -> "BoundLogger":
+        return super().unbind(*self.prefix_keys(*keys))  # type: ignore
+
+    def try_unbind(self, *keys: str) -> "BoundLogger":
+        return super().try_unbind(*self.prefix_keys(*keys))  # type: ignore
+
+    def _proxy_to_logger(
+        self, method_name: str, event: Optional[str] = None, *event_args: str, **event_kw: Any
+    ) -> Any:
+        return super()._proxy_to_logger(method_name, event, *event_args, **self.prefix_kwargs(**event_kw))


### PR DESCRIPTION
Currently the `WOODCHIPPER_KEY_PREFIX` environment variable only prepends prefixes to keys set in `LoggingContext`. This PR extends that functionality to append that prefix to keys set in `logger.bind()` calls as well as emitting individual logging messages.