### PR TITLE
Feat: Flask WSGI plugin adds url query parameters to http namespace

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Added
+
+- WSGI Flask adapter adds query param information to http.query_param namespace
+
 ## [v0.5] 16 February, 2022
 
 ### Added

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -1,5 +1,6 @@
 import json
 from unittest.mock import patch
+from urllib.parse import urlencode
 
 from flask import Flask
 
@@ -25,3 +26,26 @@ def test_flask_with_woodchipper():
     assert response_json["woodchip.testvar"] == "testval"
     assert response_json["http.method"] == "GET"
     assert response_json["http.header.host"] == "localhost"
+    assert response_json["http.path"] == "http://localhost/"
+
+
+def test_flask_with_woodchipper_adds_query_params():
+    query_dict = {
+        "key1": "value1",
+        "key2": ["val1", "val2", "val3"],  # confirms that multiple params are handled
+        "KEY3": "value3",  # confirms that it lowercases qparams
+        "key4": "",  # confirms that it can handle empty values
+    }
+    encoded = urlencode(query_dict, doseq=True)
+
+    with patch("woodchipper.context.os.getenv", return_value="woodchip"):
+        with app.test_client() as client:
+            response = client.get("/", query_string=encoded)
+
+    assert response.status_code == 200
+    response_json = json.loads(response.data)
+    assert response_json["http.query_param.key1"] == "value1"
+    assert response_json["http.query_param.key2"] == ["val1", "val2", "val3"]
+    assert response_json["http.query_param.key3"] == "value3"
+    assert response_json["http.query_param.key4"] == ""
+    assert response_json["http.path"] == "http://localhost/"  # confirms that querystring isn't included

--- a/woodchipper/http/flask.py
+++ b/woodchipper/http/flask.py
@@ -23,7 +23,13 @@ class WoodchipperFlask:
                 "id": g.request_id,
                 "body_size": request.content_length,
                 "method": request.method,
-                "url": request.url,
+                "path": request.base_url,
+                **{
+                    f"query_param.{param_key.lower()}": param_val_list[0]
+                    if len(param_val_list) == 1
+                    else param_val_list
+                    for param_key, param_val_list in request.args.lists()
+                },
                 **{
                     f"header.{header.lower()}": ("******" if header.lower() in self._blacklisted_headers else value)
                     for header, value in request.headers.items()


### PR DESCRIPTION
At a later time we may want to allow users to inject their own querystring
parsing strategy. We only need standard default parsing now
(common '&' delimiter, default type casting of param values, etc).

@j00bar thoughts on the namespace? Not married to `query_param` 🤷 , but wasn't sure what else to use.

Any delimiter/character escaping issues you think we'll run into out of the gate? I didn't take those into account. I'm not sure how common non-`&` delimiters, for instance.