### PR TITLE
Add response status_code and content_length to http.flask LoggingContext

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - WSGI Flask adapter adds query param information to http.query_param namespace
+- WSGI Flask adapter adds response status code and content length to exiting message of LoggingContext
 
 ## [v0.5] 16 February, 2022
 


### PR DESCRIPTION
Wraps vanilla_full_dispatch_request with exception handler because Flask
  will not wrap exceptions that do not inherit from HTTPError. We feel it
  reasonable to assume that the response would be 5xx level if that happens
  so we log it as such.