### PR TITLE
Add pre-v0.8 commit with Unreleased placeholder in changelog

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [v0.7] 15 July 2022
 
 - context.time_to_run_in_µsec is renamed to context.time_to_run_in_musec

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = woodchipper
-version = 0.7
+version = 0.8pre
 description = Woodchipper is a support library for plugging structured logging into a Python project.
 author = Tackle.io, Inc.
 url = https://github.com/tackle-io/woodchipper


### PR DESCRIPTION
- Sets up CHANGELOG to be ready for new updates
- Bumps version to `version = 0.8pre` in setup.cfg