### PR TITLE
Add `url_rule` to Flask WSGI adapter namespace

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add `url_rule` to WSGI Flask adapter namespace under `http.url_rule`.
 
 ## [v0.7] 15 July 2022
 

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -88,3 +88,19 @@ def test_flask_with_woodchipper_adds_query_params():
     assert response_json["http.query_param.key3"] == "value3"
     assert response_json["http.query_param.key4"] == ""
     assert response_json["http.path"] == "http://localhost/"  # confirms that querystring isn't included
+
+
+@app.route("/path/<string:_url_rule_pattern>")
+def path_with_url_pattern(_url_rule_pattern):
+    with LoggingContext(testvar="testval"):
+        return logging_ctx.as_dict()
+
+
+def test_flask_shows_url_rule():
+    with patch("woodchipper.context.os.getenv", return_value="woodchip"):
+        with app.test_client() as client:
+            response = client.get("/path/some_path_param")
+
+    assert response.status_code == 200
+    response_json = json.loads(response.data)
+    assert response_json["http.url_rule"] == "/path/<string:_url_rule_pattern>"

--- a/woodchipper/http/flask.py
+++ b/woodchipper/http/flask.py
@@ -24,6 +24,7 @@ class WoodchipperFlask:
                 "body_size": request.content_length,
                 "method": request.method,
                 "path": request.base_url,
+                "url_rule": request.url_rule.rule,
                 **{
                     f"query_param.{param_key.lower()}": param_val_list[0]
                     if len(param_val_list) == 1


### PR DESCRIPTION
Unlike `path`, `url_rule` will be stable and low cardinality for paths that have parametrized path components like `/somepath/<string:someid>`.

I want to get a DataDog facet on the url pattern, not the path, because the path can explode in cardinality (`/some/<int:seller_id>/path/<uuid:cust_id>`) while the url pattern stays roughly one per view handler.