### PR TITLE
Add Flask url_rule to Flask adapter (using `http.url_rule.rule` namespace pattern)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add `url_rule` to WSGI Flask adapter namespace under `http.url_rule`.
 
 ## [v0.7] 15 July 2022
 

--- a/woodchipper/http/flask.py
+++ b/woodchipper/http/flask.py
@@ -17,6 +17,12 @@ class WoodchipperFlask:
     def wrapped_full_dispatch_request(self):
         if not getattr(g, "request_id", None):
             g.request_id = self._request_id_factory()
+
+        if request.url_rule is None:
+            url_rule_entries = {"url_rule": None}
+        else:
+            url_rule_entries = {"url_rule.rule": request.url_rule.rule}
+
         with LoggingContext(
             "flask:request",
             **{
@@ -24,6 +30,7 @@ class WoodchipperFlask:
                 "body_size": request.content_length,
                 "method": request.method,
                 "path": request.base_url,
+                **url_rule_entries,
                 **{
                     f"query_param.{param_key.lower()}": param_val_list[0]
                     if len(param_val_list) == 1


### PR DESCRIPTION
This is an alternative approach to the one taken in the [other PR](https://github.com/tackle-io/woodchipper/pull/46).

The other PR will add `http.url_rule="/some/<string:identifier>"` to the Flask adapter logging context.

_This_ PR tries an alternative approach that sets up `url_rule` as a namespace that can have more entries: `http.url_rule.rule="/some/<string:identifier>"`

I'm taking this approach because it seems possible to me that in the future we would also want to add more pieces to the namespace, such as the key-value pairs of the interpolated pieces. In the case of a Flask route like `@app.route("/path/<string:product_id>/<string:customer_id>")`, we could end up with an `http` space that looks like:

```
...
"method": "GET",
"path": "https://domain.com/path/product45/customer200",
"url_rule.rule": "/path/<string:product_id>/<string:customer_id>",
"url_rule.matched_args.product_id": "product45",
"url_rule.matched_args.customer_id": "product200",
...
```

I couldn't figure out how to get that working just yet, so for now this implementation only adds `url_rule.rule`.