### PR TITLE
[HIPPO-148] Implement FastAPI request context

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added FastAPI integration that adds logging context for all non-404 requests.
+- Added Optional dependency on structlog-sentry to more explicitly state our lack of support for the
+  new major version.
 
 ## [v0.7] 15 July 2022
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -61,6 +61,26 @@ flask.WoodchipperFlask(app).chipperize()
 The `WoodchipperFlask` constructor also takes an optional kwarg parameter `request_id_factory`. By passing to this
 parameter an argumentless callable, you can customize how the unique request ID is generated.
 
+## Using Woodchipper with FastAPI
+
+Woodchipper ships with a built-in FastAPI integration, which wraps the entire request/response cycle in a
+`LoggingContext`, which adds headers and other basic request information to the context, including a unique ID for
+each request. Each of the keys in the context added by this integration will be prefixed with `http`.
+
+To enable the FastAPI integration, you have to modify the `FastAPI` app instance.
+
+{{< highlight python "lineNos=true,anchorLineNos=true,lineAnchors=flask" >}}
+from fastapi import FastAPI
+from woodchipper.http.fastapi import WoodchipperFastAPI
+
+app = FastAPI()
+WoodchipperFastAPI(app).chipperize()
+{{< /highlight >}}
+
+The `WoodchipperFastAPI` constructor also takes an optional kwarg parameter `request_id_factory`. By passing to this
+parameter an argumentless callable, you can customize how the unique request ID is generated.
+
+
 ## Using Woodchipper with AWS Lambda
 
 Woodchipper ships with a built-in AWS Lambda integration when using [Zappa](https://github.com/Zappa/zappa), which

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,3 +1,4 @@
+-r requirements-test.txt
 build
 twine~=3.6.0
 pip-tools~=6.4.0

--- a/requirements-test.in
+++ b/requirements-test.in
@@ -1,4 +1,7 @@
+-r requirements.txt
 pytest==6
 flask
+fastapi
 SQLAlchemy
 structlog-sentry
+requests

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,14 +4,26 @@
 #
 #    pip-compile requirements-test.in
 #
+anyio==3.6.2
+    # via starlette
 attrs==21.2.0
     # via pytest
 certifi==2021.10.8
-    # via sentry-sdk
+    # via
+    #   requests
+    #   sentry-sdk
+charset-normalizer==2.1.1
+    # via requests
 click==8.0.3
     # via flask
+fastapi==0.85.1
+    # via -r requirements-test.in
 flask==2.0.2
     # via -r requirements-test.in
+idna==3.4
+    # via
+    #   anyio
+    #   requests
 iniconfig==1.1.1
     # via pytest
 itsdangerous==2.0.1
@@ -28,19 +40,35 @@ pluggy==0.13.1
     # via pytest
 py==1.11.0
     # via pytest
+pydantic==1.10.2
+    # via fastapi
 pyparsing==3.0.6
     # via packaging
 pytest==6
     # via -r requirements-test.in
+requests==2.28.1
+    # via -r requirements-test.in
 sentry-sdk==1.5.2
     # via structlog-sentry
+sniffio==1.3.0
+    # via anyio
 sqlalchemy==1.4.28
     # via -r requirements-test.in
+starlette==0.20.4
+    # via fastapi
+structlog==21.5.0
+    # via -r requirements.txt
 structlog-sentry==1.4.0
     # via -r requirements-test.in
 toml==0.10.2
     # via pytest
+typing-extensions==4.4.0
+    # via
+    #   pydantic
+    #   starlette
 urllib3==1.26.8
-    # via sentry-sdk
+    # via
+    #   requests
+    #   sentry-sdk
 werkzeug==2.0.2
     # via flask

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -1,0 +1,120 @@
+import ast
+from unittest.mock import patch
+
+from fastapi import FastAPI, testclient
+from fastapi.testclient import TestClient
+
+import woodchipper
+from woodchipper.configs import DevLogToStdout
+from woodchipper.context import LoggingContext, logging_ctx
+from woodchipper.http.fastapi import WoodchipperFastAPI
+
+app = FastAPI()
+WoodchipperFastAPI(app).chipperize()
+
+client = TestClient(app)
+
+woodchipper.configure(
+    config=DevLogToStdout,
+    facilities={"": "INFO"},
+)
+
+
+@app.get("/")
+def hello_world():
+    with LoggingContext(testvar="testval"):
+        return logging_ctx.as_dict()
+
+
+def test_fastapi_with_woodchipper(caplog):
+    with patch("woodchipper.context.os.getenv", return_value="woodchip"):
+        response = client.get("/")
+
+    assert response.status_code == 200
+    assert response.json()["woodchip.testvar"] == "testval"
+    assert response.json()["http.method"] == "GET"
+    assert response.json()["http.header.host"] == "testserver"
+    assert response.json()["http.path"] == "http://testserver/"
+
+    # These logs won't be available until after the context has exited and the response as returned
+    fastapi_colon_request_exit_log = None
+    for log in caplog.records:
+        msg = ast.literal_eval(log.message)  # weirdly the log.message is a python dict that is a string
+        if msg["event"] == "Exiting context: fastapi:request":
+            fastapi_colon_request_exit_log = msg
+            break
+
+    assert (
+        fastapi_colon_request_exit_log is not None
+    ), "An exit message matching the flask:request pattern couldn't be found"
+    assert fastapi_colon_request_exit_log["http.response.status_code"] == 200
+    assert type(fastapi_colon_request_exit_log["http.response.content_length"]) is int
+
+
+def test_fastapi_with_woodchipper_adds_query_params():
+    query_dict = {
+        "key1": "value1",
+        "key2": ["val1", "val2", "val3"],  # confirms that multiple params are handled
+        "KEY3": "value3",  # confirms that it lowercases qparams
+        "key4": "",  # confirms that it can handle empty values
+    }
+    response = client.get("/", params=query_dict)
+
+    assert response.status_code == 200
+    assert response.json()["http.query_param.key1"] == "value1"
+    assert response.json()["http.query_param.key2"] == ["val1", "val2", "val3"]
+    assert response.json()["http.query_param.key3"] == "value3"
+    assert response.json()["http.query_param.key4"] == ""
+    assert response.json()["http.path"] == "http://testserver/"  # confirms that querystring isn't included
+
+
+def test_fastapi_header_blacklist():
+    app = FastAPI()
+    WoodchipperFastAPI(app, blacklisted_headers=["host"]).chipperize()
+    client = testclient.TestClient(app)
+
+    @app.get("/")
+    def hello():
+        return logging_ctx.as_dict()
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert response.json()["http.header.host"] == "******"
+
+
+def test_fastapi_gen_id():
+    app = FastAPI()
+    WoodchipperFastAPI(app, request_id_factory=lambda: "id").chipperize()
+    client = testclient.TestClient(app)
+
+    @app.get("/")
+    def hello():
+        return logging_ctx.as_dict()
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert response.json()["http.id"] == "id"
+
+
+def test_fastapi_uncaught_error(caplog):
+    app = FastAPI()
+    WoodchipperFastAPI(app, request_id_factory=lambda: "id").chipperize()
+    client = testclient.TestClient(app, raise_server_exceptions=False)
+
+    @app.get("/")
+    def hello():
+        raise Exception()
+
+    client.get("/")
+
+    # These logs won't be available until after the context has exited and the response as returned
+    fastapi_colon_request_exit_log = None
+    for log in caplog.records:
+        msg = ast.literal_eval(log.message)  # weirdly the log.message is a python dict that is a string
+        if msg["event"] == "Exiting context: fastapi:request":
+            fastapi_colon_request_exit_log = msg
+            break
+
+    assert fastapi_colon_request_exit_log["http.response.status_code"] == 500

--- a/woodchipper/context.py
+++ b/woodchipper/context.py
@@ -151,7 +151,13 @@ class LoggingContext:
     start_time: float
 
     def __init__(
-        self, name=None, *, _prefix=missing, _missing_default=missing, _path_delimiter=".", **kwargs: LoggableValue
+        self,
+        name=None,
+        *,
+        _prefix: Union[str, Missing] = missing,
+        _missing_default=missing,
+        _path_delimiter=".",
+        **kwargs: LoggableValue,
     ):
         self.name = name
         self.injected_context = kwargs

--- a/woodchipper/http/fastapi.py
+++ b/woodchipper/http/fastapi.py
@@ -1,0 +1,80 @@
+import uuid
+from typing import Any, Callable, Coroutine
+
+from fastapi import FastAPI, Request, Response
+
+from woodchipper.context import LoggingContext, logging_ctx
+
+BLACKLISTED_HEADERS = ["authorization", "cookie"]
+
+
+class WoodchipperFastAPI:
+    def __init__(self, app: FastAPI, blacklisted_headers=BLACKLISTED_HEADERS, request_id_factory=None):
+        self._app = app
+        self._blacklisted_headers = blacklisted_headers
+        self._request_id_factory = request_id_factory or (lambda: str(uuid.uuid4()))
+
+    def get_custom_route_handler(self, gen_id, blacklisted_headers):
+        def get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]:
+
+            original_route_handler = super(type(self), self).get_route_handler()
+
+            async def woodchipper_route_handler(request: Request) -> Response:
+
+                # When the request object parses query params it doesn't combine repeat
+                # params into a list. This doesn't happen until FastAPI is preparing to
+                # call the handling function. We do want to see repeat params as a list so
+                # we combine them here.
+                queries = {}
+                for k, v in request.query_params.multi_items():
+                    if k in queries and not isinstance(queries[k], list):
+                        queries[k] = [queries[k], v]
+                    elif k in queries:
+                        queries[k].append(v)
+                    else:
+                        queries[k] = v
+
+                with LoggingContext(
+                    "fastapi:request",
+                    **{
+                        "id": gen_id(),
+                        "body_size": int(request.headers.get("content-length", 0)),
+                        "method": request.method,
+                        "path": request.base_url._url,
+                        **{f"query_param.{k.lower()}": v for k, v in queries.items()},
+                        **{
+                            f"header.{k.lower()}": (v if k.lower() not in blacklisted_headers else "******")
+                            for k, v in request.headers.items()
+                        },
+                    },
+                    _prefix="http",
+                ):
+                    try:
+                        response: Response = await original_route_handler(request)
+                    except Exception as e:
+                        logging_ctx.update({"http.response.status_code": 500})
+                        raise e
+                    else:
+                        logging_ctx.update(
+                            {
+                                "http.response.status_code": response.status_code,
+                                "http.response.content_length": int(response.headers.get("content-length", 0)),
+                            }
+                        )
+                        return response
+
+            return woodchipper_route_handler
+
+        return get_route_handler
+
+    def get_logging_route_class(self):
+        return type(
+            "WoodChipperApiRoute",
+            (
+                self._app.router.route_class,
+            ),  # This allows us to handle cases where the routeclass has already been replaced
+            {"get_route_handler": self.get_custom_route_handler(self._request_id_factory, self._blacklisted_headers)},
+        )
+
+    def chipperize(self):
+        self._app.router.route_class = self.get_logging_route_class()


### PR DESCRIPTION
Main:
Added logging context for FastAPI.

The traditional way to insert oneself at the request level in FastAPI is by [subclassing and replacing APIRoute](https://fastapi.tiangolo.com/advanced/custom-request-and-route/?h=logging#accessing-the-request-body-in-an-exception-handler). Wanting to maintain the ability to customize the id factory and header blacklist I needed to generate that class dynamically.

The only other major change is that FastAPI doesn't have a global exception handler by default so the try, except portion has been omitted from the flask implementation.

Misc:
Update black in pre-commit to solve [this](https://github.com/psf/black/issues/2964) error.