### PR TITLE
Add structlog-sentry as optional dependency

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -84,7 +84,9 @@ app.wsgi_app = WoodchipperLambda(app.wsgi_app)
 {{< /highlight >}}
 
 ## Using Woodchipper with Sentry
-
-If you're using the `JSONLogToStdout` configuration and you have installed
-[structlog-sentry](https://github.com/kiwicom/structlog-sentry), Woodchipper will handle emitting error-level log
+There is an optional dependency for [structlog-sentry](https://github.com/kiwicom/structlog-sentry) that can be install
+using `pip install woodchipper[sentry]`. If you're using the `JSONLogToStdout` configuration and have the optional dependency installed, Woodchipper will handle emitting error-level log
 messages from your application to Sentry. You are still responsible for configuring the Sentry SDK yourself.
+
+**NOTE** As of right now we do not support structlog-sentry >= 2.0.0. If you installed `structlog-sentry` before it was added
+as an optional dependency make sure you have it pinned to a version below 2.0.0.

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -84,7 +84,7 @@ app.wsgi_app = WoodchipperLambda(app.wsgi_app)
 {{< /highlight >}}
 
 ## Using Woodchipper with Sentry
-There is an optional dependency for [structlog-sentry](https://github.com/kiwicom/structlog-sentry) that can be install
+There is an optional dependency for [structlog-sentry](https://github.com/kiwicom/structlog-sentry) that can be installed
 using `pip install woodchipper[sentry]`. If you're using the `JSONLogToStdout` configuration and have the optional dependency installed, Woodchipper will handle emitting error-level log
 messages from your application to Sentry. You are still responsible for configuring the Sentry SDK yourself.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,3 +17,7 @@ include_package_data = True
 install_requires =
     structlog>=21.5.0
 python_requires = >=3.6
+
+[options.extras_require]
+sentry =
+    structlog-sentry<2.0.0


### PR DESCRIPTION
Adding structlog-sentry as an optional dependency so we can have an official version constraint on it. Also updated the docs to reflect the change.