### PR TITLE
Add DatadogTraceProcessor for adding Datadog trace information to logs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added DatadogTraceProcessor for adding Datadog trace information to logs
 
 ## [v0.8] 3 November, 2022
 

--- a/woodchipper/configs.py
+++ b/woodchipper/configs.py
@@ -81,6 +81,7 @@ class JSONLogToStdout(BaseConfigClass):
         structlog.stdlib.PositionalArgumentsFormatter(),
         structlog.processors.StackInfoRenderer(),
         woodchipper.processors.GitVersionProcessor(),
+        woodchipper.processors.DatadogTraceProcessor(),
         structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M.%S", utc=False),
         structlog.processors.CallsiteParameterAdder(
             parameters=callsite_parameters, additional_ignores=["woodchipper"]

--- a/woodchipper/processors.py
+++ b/woodchipper/processors.py
@@ -3,6 +3,15 @@ import logging
 
 from woodchipper import context
 
+_ddtrace_present = False
+try:
+    import ddtrace
+    from ddtrace import tracer
+
+    _ddtrace_present = True
+except ImportError:
+    pass
+
 
 def inject_context_processor(logger: logging.Logger, method: str, event_dict: dict):
     """
@@ -44,12 +53,7 @@ class DatadogTraceProcessor:
     def __call__(self, logger: logging.Logger, method: str, event_dict: dict) -> dict:
         # Adapted from
         # https://docs.datadoghq.com/tracing/other_telemetry/connect_logs_and_traces/python/#no-standard-library-logging
-        try:
-            import ddtrace
-            from ddtrace import tracer
-        except ImportError:
-            # ddtrace is an optional dependency
-            # if not installed, no-op the event
+        if not _ddtrace_present:
             return event_dict
 
         # get correlation ids from current tracer context


### PR DESCRIPTION
This change adds `DatadogTraceProcessor` which as the name suggests adds trace information to logs via the [`ddtrace`](https://github.com/DataDog/dd-trace-py) library. This is used by Datadog for correlating log events and traces in the UI. 

`ddtrace` is an optional dependency. For applications that to not use `ddtrace` the processor will no nothing.

This PR also adds `DatadogTraceProcessor` to the `JSONLogToStdout` config. The processor will not cause harm for applications not instrumented with Datadog due to the aforementioned optional dependency.