### PR TITLE
[ENG-7617] Use ISO-8601 UTC timestamps in prod

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Use ISO-8601 formatted, UTC adjusted timestamps in production config
+
 ## [v0.9] 2 December, 2022
 
 - Added DatadogTraceProcessor for adding Datadog trace information to logs

--- a/woodchipper/configs.py
+++ b/woodchipper/configs.py
@@ -60,7 +60,7 @@ class DevLogToStdout(BaseConfigClass):
         structlog.processors.StackInfoRenderer(),
         structlog.dev.set_exc_info,
         structlog.processors.UnicodeDecoder(),
-        structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M.%S", utc=False),
+        structlog.processors.TimeStamper(fmt="iso", utc=False),
         structlog.processors.CallsiteParameterAdder(
             parameters=callsite_parameters, additional_ignores=["woodchipper"]
         ),
@@ -82,7 +82,7 @@ class JSONLogToStdout(BaseConfigClass):
         structlog.processors.StackInfoRenderer(),
         woodchipper.processors.GitVersionProcessor(),
         woodchipper.processors.DatadogTraceProcessor(),
-        structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M.%S", utc=False),
+        structlog.processors.TimeStamper(fmt="iso", utc=True),
         structlog.processors.CallsiteParameterAdder(
             parameters=callsite_parameters, additional_ignores=["woodchipper"]
         ),


### PR DESCRIPTION
For whatever reason, I declined to use ISO-8601 timestamps and in prod I declined to use UTC, let alone to publish the local timezone offset.

This remedies that muppetry.