### PR TITLE
[HIPPO-311] Allow users to override prefix set by environment vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ cython_debug/
 
 version.json
 node_modules/
+
+# VSCode
+.vscode

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,33 +1,33 @@
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.2.0
-  hooks:
-  - id: trailing-whitespace
-  - id: end-of-file-fixer
-  - id: check-yaml
-  - id: check-case-conflict
-  - id: check-json
-  - id: check-merge-conflict
-  - id: debug-statements
-  - id: detect-aws-credentials
-- repo: https://github.com/psf/black
-  rev: 22.3.0
-  hooks:
-  - id: black
-    language_version: python3
-    args: ["--config", "pyproject.toml"]
-- repo: https://github.com/pycqa/isort
-  rev: 5.9.3
-  hooks:
-  - id: isort
-    args: ["--profile", "black", "-l", "119"]
-- repo: https://github.com/pycqa/flake8
-  rev: "3.9.2"
-  hooks:
-  - id: flake8
-    args: ["--max-line-length=119", "--extend-ignore=E203"]
-- repo: https://github.com/pycqa/bandit
-  rev: "1.7.1"
-  hooks:
-  - id: bandit
-    args: ["-r", "-ll", "-ii"]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-case-conflict
+      - id: check-json
+      - id: check-merge-conflict
+      - id: debug-statements
+      - id: detect-aws-credentials
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        language_version: python3
+        args: ["--config", "pyproject.toml"]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        args: ["--profile", "black", "-l", "119"]
+  - repo: https://github.com/pycqa/flake8
+    rev: "3.9.2"
+    hooks:
+      - id: flake8
+        args: ["--max-line-length=119", "--extend-ignore=E203"]
+  - repo: https://github.com/pycqa/bandit
+    rev: "1.7.1"
+    hooks:
+      - id: bandit
+        args: ["-r", "-ll", "-ii"]

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Sets log key prefix as an instance variable on BoundLogger rather than checking the environment variable with each call
+- Allows log key prefix to be cleared by users with clear_prefix function
+
 ## [v0.10] 6 December, 2022
 
 - Use ISO-8601 formatted, UTC adjusted timestamps in production config
@@ -23,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.7] 15 July 2022
 
-- context.time_to_run_in_µsec is renamed to context.time_to_run_in_musec
+- context.time*to_run_in*µsec is renamed to context.time_to_run_in_musec
 
 ## [v0.6] 26 May, 2022
 
@@ -47,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - AWS Lambda sentinel check
 - Packaging metadata to reflect the move under Tackle's aegis
+
 ### Added
 
 - Names for logging contexts
@@ -54,10 +58,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v0.3] 30 December, 2021
 
 ### Added
+
 - Added static type checking configuration
 - Added extra keys to lambda context for function name and version
 
 ### Fixed
+
 - Fixed incorrect type hint on `woodchipper.configure` (#19)
 - Fixed all pyright complaints
 - Renamed lambda module to something more easily importable (#17)
@@ -65,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v0.2] 22 December, 2021
 
 ### Added
+
 - Structlog configuration wrapper
 - Contextual logging with context manager and decorator
 - WSGI adapters for Lambda and Flask

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.7] 15 July 2022
 
-- context.time*to_run_in*µsec is renamed to context.time_to_run_in_musec
+- context.time_to_run_in_µsec is renamed to context.time_to_run_in_musec
 
 ## [v0.6] 26 May, 2022
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -13,6 +13,8 @@ If set, any context variable emitted that does not have an explicit prefix set f
 For example, if you set this environment variable to `tackle`, then a key `user` would appear in log messages as
 `tackle.user`.
 
+If you want to override this, call the clear_prefix() function on the logger once initialized.
+
 ### `WOODCHIPPER_DISABLE_SENTRY`
 
 If set to a non-empty value, the built-in Sentry integration will be disabled.

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -24,3 +24,19 @@ def test_bind_log_prefix():
         assert messages[1]["footest.b"] == 2
         assert messages[1]["customprefix.bar"] == "baz"
         assert messages[1]["footest.a"] == 1
+
+
+# When WOODCHIPPER_KEY_PREFIX is set, ensure calling clear_prefix() allows subsequent
+# logger calls are output without a prefix
+def test_clear_prefix():
+    with patch.dict(os.environ, dict(WOODCHIPPER_KEY_PREFIX="footest")):
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            woodchipper.configure(config=woodchipper.configs.Minimal, facilities={"": "INFO"})
+            logger = woodchipper.get_logger(__name__)
+            logger.clear_prefix()
+            logger.info("Message one.", c=3)
+        messages = [json.loads(message) for message in buf.getvalue().strip().split("\n")]
+        assert messages[0]["event"] == "Message one."
+        assert messages[0]["level"] == "info"
+        assert messages[0]["c"] == 3

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -17,13 +17,14 @@ def test_bind_log_prefix():
             logger.info("Message one.", a=1)
             logger_with_ctx = logger.bind(**{"b": 2, "customprefix.bar": "baz"})
             logger_with_ctx.info("Message two.", a=1)
-        messages = [json.loads(message) for message in buf.getvalue().strip().split("\n")]
+            messages = [json.loads(message) for message in buf.getvalue().strip().split("\n")]
         assert messages[0]["event"] == "Message one."
         assert messages[0]["level"] == "info"
         assert messages[0]["footest.a"] == 1
         assert messages[1]["footest.b"] == 2
         assert messages[1]["customprefix.bar"] == "baz"
         assert messages[1]["footest.a"] == 1
+        buf.close()
 
 
 # When WOODCHIPPER_KEY_PREFIX is set, ensure calling clear_prefix() allows subsequent
@@ -33,10 +34,11 @@ def test_clear_prefix():
         buf = io.StringIO()
         with contextlib.redirect_stdout(buf):
             woodchipper.configure(config=woodchipper.configs.Minimal, facilities={"": "INFO"})
-            logger = woodchipper.get_logger(__name__)
+            logger = woodchipper.get_logger("test_prefix")
             logger.clear_prefix()
             logger.info("Message one.", c=3)
-        messages = [json.loads(message) for message in buf.getvalue().strip().split("\n")]
+            messages = [json.loads(message) for message in buf.getvalue().strip().split("\n")]
         assert messages[0]["event"] == "Message one."
         assert messages[0]["level"] == "info"
         assert messages[0]["c"] == 3
+        buf.close()

--- a/woodchipper/__init__.py
+++ b/woodchipper/__init__.py
@@ -61,7 +61,7 @@ def configure(
         wrapper_class=config.wrapper_class,
         context_class=dict,
         logger_factory=config.factory,
-        cache_logger_on_first_use=False,
+        cache_logger_on_first_use=True,
     )
 
 

--- a/woodchipper/logger.py
+++ b/woodchipper/logger.py
@@ -43,6 +43,4 @@ class BoundLogger(StdlibBoundLogger):
     def _proxy_to_logger(
         self, method_name: str, event: Optional[str] = None, *event_args: str, **event_kw: Any
     ) -> Any:
-        return super()._proxy_to_logger(
-            method_name, event, *event_args, **(self.prefix_kwargs(**event_kw) if self.key_prefix else event_kw)
-        )
+        return super()._proxy_to_logger(method_name, event, *event_args, **self.prefix_kwargs(**event_kw))

--- a/woodchipper/logger.py
+++ b/woodchipper/logger.py
@@ -7,7 +7,7 @@ NO_PREFIX_LIST = ["exc_info"]
 
 
 class BoundLogger(StdlibBoundLogger):
-    key_prefix: str = ""
+    __key_prefix__: str = ""
 
     def __init__(self, *args, **kwargs):
         self.key_prefix = os.getenv("WOODCHIPPER_KEY_PREFIX", "")


### PR DESCRIPTION
### Overview

Creates an instance variable, key_prefix, on instances of BoundLogger, which can be set based on the value of environment variables and cleared by the users. Adds a test and updates docs and the change log.

Currently, the tests are failing based on the order in which they're run-- I'm looking into this.
