### PR TITLE
[HIPPO-605] Rewrite FastAPI integration as middleware

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -10,15 +10,15 @@ When a `LoggingContext` exits, it emits a log message saying so. That message in
 which the `LoggingContext` was defined. You may want to customize that name to something more understandable. To do
 this, provide a single positional argument to `LoggingContext` when you define it. That name will be used instead.
 
-{{< highlight python "lineNos=true,anchorLineNos=true,lineAnchors=namingloggingcontext" >}}
+```python {linenos=table}
 with LoggingContext("custom-name", user=request.user.id):
-{{< /highlight >}}
+```
 
 When this context exits, the message will use the custom name instead of the module and function name.
 
-{{< highlight shell "lineNos=true,anchorLineNos=true,lineAnchors=namingloggingcontextoutput" >}}
+```python {linenos=table}
 2022-01-20 10:49.54 [info     ] Exiting context: custom-name [woodchipper.context] context.time_to_run_musec=1318 func_name=<module> lineno=1 module=<stdin> user=1000
-{{< /highlight >}}
+```
 
 ## Namespacing context variables with a prefix
 
@@ -33,10 +33,10 @@ key name, so it became `tackle.data` instead of simply `data`.
 You can also set the prefix on a `LoggingContext`, overriding the default key prefix, with the `_prefix` kwarg. For
 example:
 
-{{< highlight shell "lineNos=true,anchorLineNos=true,lineAnchors=prefix" >}}
+```python {linenos=table}
 with LoggingContext(user=request.user.id, _prefix="demo"):
     logging.info("Demo beginning.")
-{{< /highlight >}}
+```
 
 In the above message, the `user` contextual key would be outputted as `demo.user`, regardless of the value of the
 `WOODCHIPPER_KEY_PREFIX` environment variable.
@@ -50,13 +50,13 @@ each request. Each of the keys in the context added by this integration will be 
 To enable the Flask integration, you have to modify the `Flask` app isntance. This is non-standard versus other Flask
 extensions, where you simply wrap the Flask object.
 
-{{< highlight python "lineNos=true,anchorLineNos=true,lineAnchors=flask" >}}
+```python {linenos=table}
 from flask import Flask
 from woodchipper.http.flask import WoodchipperFlask
 
 app = Flask(__name__)
 flask.WoodchipperFlask(app).chipperize()
-{{< /highlight >}}
+```
 
 The `WoodchipperFlask` constructor also takes an optional kwarg parameter `request_id_factory`. By passing to this
 parameter an argumentless callable, you can customize how the unique request ID is generated.
@@ -75,22 +75,22 @@ However, if you also have Datadog's DDTrace middleware installed on the same app
 tracing to break. In those cases, manual installation (see second example) is preferred.
 
 Chipperize:
-{{< highlight python "lineNos=true,anchorLineNos=true,lineAnchors=flask" >}}
+```python {linenos=table}
 from fastapi import FastAPI
 from woodchipper.http.fastapi import WoodchipperFastAPI
 
 app = FastAPI()
 WoodchipperFastAPI(app).chipperize()
-{{< /highlight >}}
+```
 
 Manual installation:
-{{< highlight python "lineNos=true,anchorLineNos=true,lineAnchors=flask" >}}
+```python {linenos=table}
 from fastapi import FastAPI
 from woodchipper.http.fastapi import WoodchipperFastAPI
 
 app = FastAPI()
 app.add_middleware(WoodchipperFastAPI)
-{{< /highlight >}}
+```
 
 The `WoodchipperFastAPI` constructor also takes an optional kwarg parameter `request_id_factory`. By passing to this
 parameter an argumentless callable, you can customize how the unique request ID is generated.
@@ -104,7 +104,7 @@ execution environment. Each of the keys in the context added by this integration
 
 To enable the Lambda integration, you have to use it like a WSGI middleware.
 
-{{< highlight python "lineNos=true,anchorLineNos=true,lineAnchors=lambda" >}}
+```python {linenos=table}
 # Let's say your WSGI callable is named app
 from woodchipper.http.awslambda import WoodchipperLambda
 
@@ -116,7 +116,7 @@ from flask import Flask
 
 app = Flask(__name__)
 app.wsgi_app = WoodchipperLambda(app.wsgi_app)
-{{< /highlight >}}
+```
 
 ## Using Woodchipper with Sentry
 There is an optional dependency for [structlog-sentry](https://github.com/kiwicom/structlog-sentry) that can be installed

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -69,12 +69,27 @@ each request. Each of the keys in the context added by this integration will be 
 
 To enable the FastAPI integration, you have to modify the `FastAPI` app instance.
 
+There are two ways to do this. The first, chipperize() is the recommended approach to get accurate timing data
+in most cases-- it ensures the Woodchipper middleware is the first in the middleware stack.
+However, if you also have Datadog's DDTrace middleware installed on the same application, chipperize may cause
+tracing to break. In those cases, manual installation (see second example) is preferred.
+
+Chipperize:
 {{< highlight python "lineNos=true,anchorLineNos=true,lineAnchors=flask" >}}
 from fastapi import FastAPI
 from woodchipper.http.fastapi import WoodchipperFastAPI
 
 app = FastAPI()
 WoodchipperFastAPI(app).chipperize()
+{{< /highlight >}}
+
+Manual installation:
+{{< highlight python "lineNos=true,anchorLineNos=true,lineAnchors=flask" >}}
+from fastapi import FastAPI
+from woodchipper.http.fastapi import WoodchipperFastAPI
+
+app = FastAPI()
+app.add_middleware(WoodchipperFastAPI)
 {{< /highlight >}}
 
 The `WoodchipperFastAPI` constructor also takes an optional kwarg parameter `request_id_factory`. By passing to this

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -7,10 +7,10 @@ from fastapi.testclient import TestClient
 import woodchipper
 from woodchipper.configs import DevLogToStdout
 from woodchipper.context import LoggingContext, logging_ctx
-from woodchipper.http.fastapi import install_woodchipper_middleware
+from woodchipper.http.fastapi import WoodchipperFastAPI
 
 app = FastAPI()
-install_woodchipper_middleware(app)
+WoodchipperFastAPI(app).chipperize()
 client = TestClient(app)
 
 woodchipper.configure(
@@ -69,7 +69,7 @@ def test_fastapi_with_woodchipper_adds_query_params():
 
 def test_fastapi_header_blacklist():
     app = FastAPI()
-    install_woodchipper_middleware(app, blacklisted_headers=["host"])
+    WoodchipperFastAPI(app, blacklisted_headers=["host"]).chipperize()
     client = testclient.TestClient(app)
 
     @app.get("/")
@@ -84,7 +84,7 @@ def test_fastapi_header_blacklist():
 
 def test_fastapi_gen_id():
     app = FastAPI()
-    install_woodchipper_middleware(app, request_id_factory=lambda: "id")
+    WoodchipperFastAPI(app, request_id_factory=lambda: "id").chipperize()
     client = testclient.TestClient(app)
 
     @app.get("/")
@@ -99,7 +99,7 @@ def test_fastapi_gen_id():
 
 def test_fastapi_uncaught_error(caplog):
     app = FastAPI()
-    install_woodchipper_middleware(app, request_id_factory=lambda: "id")
+    WoodchipperFastAPI(app, request_id_factory=lambda: "id").chipperize()
     client = testclient.TestClient(app, raise_server_exceptions=False)
 
     @app.get("/")

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -10,8 +10,10 @@ from woodchipper.context import LoggingContext, logging_ctx
 from woodchipper.http.fastapi import WoodchipperFastAPI
 
 app = FastAPI()
-WoodchipperFastAPI(app).chipperize()
-client = TestClient(app)
+woodchipper_app = WoodchipperFastAPI(app)
+woodchipper_app.chipperize()
+client = TestClient(woodchipper_app)
+
 
 woodchipper.configure(
     config=DevLogToStdout,
@@ -69,8 +71,9 @@ def test_fastapi_with_woodchipper_adds_query_params():
 
 def test_fastapi_header_blacklist():
     app = FastAPI()
-    WoodchipperFastAPI(app, blacklisted_headers=["host"]).chipperize()
-    client = testclient.TestClient(app)
+    woodchipper_app = WoodchipperFastAPI(app, blacklisted_headers=["host"])
+    woodchipper_app.chipperize()
+    client = testclient.TestClient(woodchipper_app)
 
     @app.get("/")
     def hello():
@@ -83,9 +86,9 @@ def test_fastapi_header_blacklist():
 
 
 def test_fastapi_gen_id():
-    app = FastAPI()
-    WoodchipperFastAPI(app, request_id_factory=lambda: "id").chipperize()
-    client = testclient.TestClient(app)
+    woodchipper_app = WoodchipperFastAPI(app, request_id_factory=lambda: "id")
+    woodchipper_app.chipperize()
+    client = testclient.TestClient(woodchipper_app)
 
     @app.get("/")
     def hello():
@@ -99,8 +102,9 @@ def test_fastapi_gen_id():
 
 def test_fastapi_uncaught_error(caplog):
     app = FastAPI()
-    WoodchipperFastAPI(app, request_id_factory=lambda: "id").chipperize()
-    client = testclient.TestClient(app, raise_server_exceptions=False)
+    woodchipper_app = WoodchipperFastAPI(app, request_id_factory=lambda: "id")
+    woodchipper_app.chipperize()
+    client = testclient.TestClient(woodchipper_app, raise_server_exceptions=False)
 
     @app.get("/")
     def hello():

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -7,11 +7,10 @@ from fastapi.testclient import TestClient
 import woodchipper
 from woodchipper.configs import DevLogToStdout
 from woodchipper.context import LoggingContext, logging_ctx
-from woodchipper.http.fastapi import WoodchipperFastAPI
+from woodchipper.http.fastapi import install_woodchipper_middleware
 
 app = FastAPI()
-WoodchipperFastAPI(app).chipperize()
-
+install_woodchipper_middleware(app)
 client = TestClient(app)
 
 woodchipper.configure(
@@ -70,7 +69,7 @@ def test_fastapi_with_woodchipper_adds_query_params():
 
 def test_fastapi_header_blacklist():
     app = FastAPI()
-    WoodchipperFastAPI(app, blacklisted_headers=["host"]).chipperize()
+    install_woodchipper_middleware(app, blacklisted_headers=["host"])
     client = testclient.TestClient(app)
 
     @app.get("/")
@@ -85,7 +84,7 @@ def test_fastapi_header_blacklist():
 
 def test_fastapi_gen_id():
     app = FastAPI()
-    WoodchipperFastAPI(app, request_id_factory=lambda: "id").chipperize()
+    install_woodchipper_middleware(app, request_id_factory=lambda: "id")
     client = testclient.TestClient(app)
 
     @app.get("/")
@@ -100,7 +99,7 @@ def test_fastapi_gen_id():
 
 def test_fastapi_uncaught_error(caplog):
     app = FastAPI()
-    WoodchipperFastAPI(app, request_id_factory=lambda: "id").chipperize()
+    install_woodchipper_middleware(app, request_id_factory=lambda: "id")
     client = testclient.TestClient(app, raise_server_exceptions=False)
 
     @app.get("/")

--- a/woodchipper/http/fastapi.py
+++ b/woodchipper/http/fastapi.py
@@ -1,80 +1,70 @@
 import uuid
-from typing import Any, Callable, Coroutine
 
 from fastapi import FastAPI, Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 
 from woodchipper.context import LoggingContext, logging_ctx
 
 BLACKLISTED_HEADERS = ["authorization", "cookie"]
 
 
-class WoodchipperFastAPI:
-    def __init__(self, app: FastAPI, blacklisted_headers=BLACKLISTED_HEADERS, request_id_factory=None):
-        self._app = app
+class WoodchipperFastAPIMiddleware(BaseHTTPMiddleware):
+    def __init__(
+        self,
+        app: FastAPI,
+        request_id_factory=None,
+        blacklisted_headers=BLACKLISTED_HEADERS,
+    ):
+        super().__init__(app)
         self._blacklisted_headers = blacklisted_headers
         self._request_id_factory = request_id_factory or (lambda: str(uuid.uuid4()))
 
-    def get_custom_route_handler(self, gen_id, blacklisted_headers):
-        def get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]:
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        # When the request object parses query params it doesn't combine repeat
+        # params into a list. This doesn't happen until FastAPI is preparing to
+        # call the handling function. We do want to see repeat params as a list so
+        # we combine them here.
+        queries = {}
+        for k, v in request.query_params.multi_items():
+            if k in queries and not isinstance(queries[k], list):
+                queries[k] = [queries[k], v]
+            elif k in queries:
+                queries[k].append(v)
+            else:
+                queries[k] = v
 
-            original_route_handler = super(type(self), self).get_route_handler()
+        with LoggingContext(
+            "fastapi:request",
+            **{
+                "id": self._request_id_factory(),
+                "body_size": int(request.headers.get("content-length", 0)),
+                "method": request.method,
+                "path": request.base_url._url,
+                **{f"query_param.{k.lower()}": v for k, v in queries.items()},
+                **{
+                    f"header.{k.lower()}": (v if k.lower() not in self._blacklisted_headers else "******")
+                    for k, v in request.headers.items()
+                },
+            },
+            _prefix="http",
+        ):
+            try:
+                response: Response = await call_next(request)
+            except Exception as e:
+                logging_ctx.update({"http.response.status_code": 500})
+                raise e
+            else:
+                logging_ctx.update(
+                    {
+                        "http.response.status_code": response.status_code,
+                        "http.response.content_length": int(response.headers.get("content-length", 0)),
+                    }
+                )
 
-            async def woodchipper_route_handler(request: Request) -> Response:
+                return response
 
-                # When the request object parses query params it doesn't combine repeat
-                # params into a list. This doesn't happen until FastAPI is preparing to
-                # call the handling function. We do want to see repeat params as a list so
-                # we combine them here.
-                queries = {}
-                for k, v in request.query_params.multi_items():
-                    if k in queries and not isinstance(queries[k], list):
-                        queries[k] = [queries[k], v]
-                    elif k in queries:
-                        queries[k].append(v)
-                    else:
-                        queries[k] = v
 
-                with LoggingContext(
-                    "fastapi:request",
-                    **{
-                        "id": gen_id(),
-                        "body_size": int(request.headers.get("content-length", 0)),
-                        "method": request.method,
-                        "path": request.base_url._url,
-                        **{f"query_param.{k.lower()}": v for k, v in queries.items()},
-                        **{
-                            f"header.{k.lower()}": (v if k.lower() not in blacklisted_headers else "******")
-                            for k, v in request.headers.items()
-                        },
-                    },
-                    _prefix="http",
-                ):
-                    try:
-                        response: Response = await original_route_handler(request)
-                    except Exception as e:
-                        logging_ctx.update({"http.response.status_code": 500})
-                        raise e
-                    else:
-                        logging_ctx.update(
-                            {
-                                "http.response.status_code": response.status_code,
-                                "http.response.content_length": int(response.headers.get("content-length", 0)),
-                            }
-                        )
-                        return response
-
-            return woodchipper_route_handler
-
-        return get_route_handler
-
-    def get_logging_route_class(self):
-        return type(
-            "WoodChipperApiRoute",
-            (
-                self._app.router.route_class,
-            ),  # This allows us to handle cases where the routeclass has already been replaced
-            {"get_route_handler": self.get_custom_route_handler(self._request_id_factory, self._blacklisted_headers)},
-        )
-
-    def chipperize(self):
-        self._app.router.route_class = self.get_logging_route_class()
+def install_woodchipper_middleware(app: FastAPI, blacklisted_headers=BLACKLISTED_HEADERS, request_id_factory=None):
+    app.add_middleware(
+        WoodchipperFastAPIMiddleware, blacklisted_headers=blacklisted_headers, request_id_factory=request_id_factory
+    )

--- a/woodchipper/http/fastapi.py
+++ b/woodchipper/http/fastapi.py
@@ -16,7 +16,6 @@ class WoodchipperFastAPI:
         request_id_factory=None,
         blacklisted_headers=BLACKLISTED_HEADERS,
     ):
-        super().__init__()
         self._app = app
         self._blacklisted_headers = blacklisted_headers
         self._request_id_factory = request_id_factory or (lambda: str(uuid.uuid4()))
@@ -33,10 +32,10 @@ class WoodchipperFastAPI:
         return __wrapped__
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        #     # When the request object parses query params it doesn't combine repeat
-        #     # params into a list. This doesn't happen until FastAPI is preparing to
-        #     # call the handling function. We do want to see repeat params as a list so
-        #     # we combine them here.
+        # When the request object parses query params it doesn't combine repeat
+        # params into a list. This doesn't happen until FastAPI is preparing to
+        # call the handling function. We do want to see repeat params as a list so
+        # we combine them here.
         if scope["type"] != "http":
             return await self._app(scope, receive, send)
         request = Request(scope)
@@ -76,9 +75,9 @@ class WoodchipperFastAPI:
         ):
             try:
                 await self._app(scope, receive, send_with_extra_headers)
-            except Exception as e:
+            except Exception:
                 logging_ctx.update({"http.response.status_code": 500})
-                raise e
+                raise
 
     def chipperize(self):
         self._app.build_middleware_stack = self._wrap_build_middleware_stack(self._app.build_middleware_stack)

--- a/woodchipper/http/fastapi.py
+++ b/woodchipper/http/fastapi.py
@@ -8,7 +8,7 @@ from woodchipper.context import LoggingContext, logging_ctx
 BLACKLISTED_HEADERS = ["authorization", "cookie"]
 
 
-class WoodchipperFastAPIMiddleware(BaseHTTPMiddleware):
+class WoodchipperFastAPI(BaseHTTPMiddleware):
     def __init__(
         self,
         app: FastAPI,
@@ -63,8 +63,9 @@ class WoodchipperFastAPIMiddleware(BaseHTTPMiddleware):
 
                 return response
 
-
-def install_woodchipper_middleware(app: FastAPI, blacklisted_headers=BLACKLISTED_HEADERS, request_id_factory=None):
-    app.add_middleware(
-        WoodchipperFastAPIMiddleware, blacklisted_headers=blacklisted_headers, request_id_factory=request_id_factory
-    )
+    def chipperize(self):
+        self.app.add_middleware(
+            WoodchipperFastAPI,
+            blacklisted_headers=self._blacklisted_headers,
+            request_id_factory=self._request_id_factory,
+        )


### PR DESCRIPTION
Fixes an issue with the FastAPI integration where routes created from an APIRouter were not being handled by the integration, by switching from a custom `route_class` to a middleware-based approach. This way, we won't have to set the `route_class` attribute for each additional APIRouter we spin up in a given service.

I tested this locally with TAS, and it behaved as expected when emitting log messages.