### PR TITLE
[DEV] add enter context logging, drop LL to debug

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,2 @@
-layout pyenv 3.8.12
+layout pyenv 3.11.5
 dotenv_if_exists

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,4 +28,4 @@ jobs:
         run: |
           pip install tox
       - name: Run tox
-        run: tox -e pre-commit
+        run: tox -e precommit

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -55,7 +55,7 @@ def test_logging_context_name():
 
     ctx_obj = context.LoggingContext(a=1, _prefix="test")
     with ctx_obj:
-        assert ctx_obj.name is None
+        assert ctx_obj.name == "test_context:test_logging_context_name"
     assert ctx_obj.name == "test_context:test_logging_context_name"
 
     ctx_obj = context.LoggingContext("test-name", a="x", _prefix="test")

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -63,10 +63,10 @@ def test_fastapi_with_woodchipper(client, caplog):
 
     assert (
         fastapi_colon_request_enter_log is not None
-    ), "An enter message matching the flask:request pattern couldn't be found"
+    ), "An enter message matching the fastapi:request pattern couldn't be found"
     assert (
         fastapi_colon_request_exit_log is not None
-    ), "An exit message matching the flask:request pattern couldn't be found"
+    ), "An exit message matching the fastapi:request pattern couldn't be found"
     assert fastapi_colon_request_exit_log["http.response.status_code"] == 200
     assert type(fastapi_colon_request_exit_log["http.response.content_length"]) is int
 
@@ -183,9 +183,9 @@ def test_alternate_installation(caplog):
 
     assert (
         fastapi_colon_request_enter_log is not None
-    ), "An enter message matching the flask:request pattern couldn't be found"
+    ), "An enter message matching the fastapi:request pattern couldn't be found"
     assert (
         fastapi_colon_request_exit_log is not None
-    ), "An exit message matching the flask:request pattern couldn't be found"
+    ), "An exit message matching the fastapi:request pattern couldn't be found"
     assert fastapi_colon_request_exit_log["http.response.status_code"] == 200
     assert type(fastapi_colon_request_exit_log["http.response.content_length"]) is int

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -1,4 +1,5 @@
 import ast
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -36,6 +37,7 @@ woodchipper.configure(
 
 
 def test_fastapi_with_woodchipper(client, caplog):
+    caplog.set_level(logging.DEBUG)
     with patch("woodchipper.context.os.getenv", return_value="woodchip"):
         response = client.get("/foo")
 
@@ -120,6 +122,7 @@ def test_fastapi_gen_id():
 
 
 def test_fastapi_uncaught_error(caplog):
+    caplog.set_level(logging.DEBUG)
     app = FastAPI()
     WoodchipperFastAPI(app, request_id_factory=lambda: "id").chipperize()
     client = testclient.TestClient(app, raise_server_exceptions=False)
@@ -142,6 +145,7 @@ def test_fastapi_uncaught_error(caplog):
 
 
 def test_alternate_installation(caplog):
+    caplog.set_level(logging.DEBUG)
     # If users do not want to use chipperize, which overrides the middleware installation order,
     # they can install using the typical FastAPI add_middleware pattern
     app = FastAPI()

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -46,13 +46,22 @@ def test_fastapi_with_woodchipper(client, caplog):
     assert response.json()["http.path"] == "http://testserver/foo"
 
     # These logs won't be available until after the context has exited and the response as returned
+    fastapi_colon_request_enter_log = None
     fastapi_colon_request_exit_log = None
     for log in caplog.records:
         msg = ast.literal_eval(log.message)  # weirdly the log.message is a python dict that is a string
+        if msg["event"] == "Entering context: fastapi:request":
+            fastapi_colon_request_enter_log = msg
+
         if msg["event"] == "Exiting context: fastapi:request":
             fastapi_colon_request_exit_log = msg
+
+        if fastapi_colon_request_enter_log and fastapi_colon_request_exit_log:
             break
 
+    assert (
+        fastapi_colon_request_enter_log is not None
+    ), "An enter message matching the flask:request pattern couldn't be found"
     assert (
         fastapi_colon_request_exit_log is not None
     ), "An exit message matching the flask:request pattern couldn't be found"
@@ -155,13 +164,22 @@ def test_alternate_installation(caplog):
     assert response.json()["http.path"] == "http://testserver/foo"
 
     # These logs won't be available until after the context has exited and the response as returned
+    fastapi_colon_request_enter_log = None
     fastapi_colon_request_exit_log = None
     for log in caplog.records:
         msg = ast.literal_eval(log.message)  # weirdly the log.message is a python dict that is a string
+        if msg["event"] == "Entering context: fastapi:request":
+            fastapi_colon_request_enter_log = msg
+
         if msg["event"] == "Exiting context: fastapi:request":
             fastapi_colon_request_exit_log = msg
+
+        if fastapi_colon_request_enter_log and fastapi_colon_request_exit_log:
             break
 
+    assert (
+        fastapi_colon_request_enter_log is not None
+    ), "An enter message matching the flask:request pattern couldn't be found"
     assert (
         fastapi_colon_request_exit_log is not None
     ), "An exit message matching the flask:request pattern couldn't be found"

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -1,5 +1,6 @@
 import ast
 import json
+import logging
 from unittest.mock import patch
 from urllib.parse import urlencode
 
@@ -19,6 +20,7 @@ def hello_world():
 
 
 def test_flask_with_woodchipper(caplog):
+    caplog.set_level(logging.DEBUG)
     with patch("woodchipper.context.os.getenv", return_value="woodchip"):
         with app.test_client() as client:
             response = client.get("/")
@@ -59,6 +61,7 @@ def raise_unhandled_exception():
 
 
 def test_flask_raises_unhandled_exception(caplog):
+    caplog.set_level(logging.DEBUG)
     with app.test_client() as client:
         response = client.get("/raise_unhandled_exception")
     assert response.status_code == 500

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -30,13 +30,22 @@ def test_flask_with_woodchipper(caplog):
     assert response_json["http.path"] == "http://localhost/"
 
     # These logs won't be available until after the context has exited and the response as returned
+    flask_colon_request_enter_log = None
     flask_colon_request_exit_log = None
     for log in caplog.records:
         msg = ast.literal_eval(log.message)  # weirdly the log.message is a python dict that is a string
+        if msg["event"] == "Entering context: flask:request":
+            flask_colon_request_enter_log = msg
+
         if msg["event"] == "Exiting context: flask:request":
             flask_colon_request_exit_log = msg
+
+        if flask_colon_request_exit_log and flask_colon_request_exit_log:
             break
 
+    assert (
+        flask_colon_request_enter_log is not None
+    ), "An exit message matching the flask:request pattern couldn't be found"
     assert (
         flask_colon_request_exit_log is not None
     ), "An exit message matching the flask:request pattern couldn't be found"
@@ -55,13 +64,22 @@ def test_flask_raises_unhandled_exception(caplog):
     assert response.status_code == 500
 
     # These logs won't be available until after the context has exited and the response as returned
+    flask_colon_request_enter_log = None
     flask_colon_request_exit_log = None
     for log in caplog.records:
         msg = ast.literal_eval(log.message)  # weirdly the log.message is a python dict that is a string
+        if msg["event"] == "Entering context: flask:request":
+            flask_colon_request_enter_log = msg
+
         if msg["event"] == "Exiting context: flask:request":
             flask_colon_request_exit_log = msg
+
+        if flask_colon_request_exit_log and flask_colon_request_exit_log:
             break
 
+    assert (
+        flask_colon_request_enter_log is not None
+    ), "An exit message matching the flask:request pattern couldn't be found"
     assert (
         flask_colon_request_exit_log is not None
     ), "An exit message matching the flask:request pattern couldn't be found"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -28,7 +28,7 @@ class TestWoodchipperLogging:
             {"event": "Warning Log Test", "log_level": "warning"},
             {"event": "Error Log Test", "log_level": "error"},
             {"event": "Critical Log Test", "log_level": "critical"},
-            {"exc_info": True, "event": "Exception Log Test", "log_level": "error"},
+            {"exc_info": True, "event": "Exception Log Test", "log_level": "exception"},
         ]
 
     @pytest.mark.skip("Figure out a way to test based on what actually get handled.")

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ isolated_build = True
 deps =
     .[dev]
 commands =
-    pytest tests/
+    pytest -vv tests/
 
 [testenv:precommit]
 deps =

--- a/woodchipper/context.py
+++ b/woodchipper/context.py
@@ -171,9 +171,20 @@ class LoggingContext:
         self._token = logging_ctx.update(
             {(f"{self.prefix}.{k}" if self.prefix else k): v for k, v in self.injected_context.items()}
         )
+
+        current_frame = inspect.currentframe()
+        calling_frame = inspect.getouterframes(current_frame, 2)[1]
+        module = inspect.getmodule(calling_frame[0])
+        module_name = module.__name__ if module else "<unknown>"
+        if self.name is None:
+            func_name = calling_frame[3]
+            self.name = f"{module_name}:{func_name}"
+
         for monitor in self._monitors:
             monitor.setup()
         self.start_time = time.time()
+
+        woodchipper.get_logger(module_name).info(f"Entering context: {self.name}", context_name=self.name)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         current_frame = inspect.currentframe()

--- a/woodchipper/context.py
+++ b/woodchipper/context.py
@@ -184,7 +184,7 @@ class LoggingContext:
             monitor.setup()
         self.start_time = time.time()
 
-        woodchipper.get_logger(module_name).info(f"Entering context: {self.name}", context_name=self.name)
+        woodchipper.get_logger(module_name).debug(f"Entering context: {self.name}", context_name=self.name)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         current_frame = inspect.currentframe()
@@ -200,7 +200,7 @@ class LoggingContext:
         monitored_data.update({"context.time_to_run_musec": int((time.time() - self.start_time) * 1e6)})
         for monitor in self._monitors:
             monitored_data.update(monitor.finish())
-        woodchipper.get_logger(module_name).info(
+        woodchipper.get_logger(module_name).debug(
             f"Exiting context: {self.name}", context_name=self.name, **monitored_data
         )
         assert self._token


### PR DESCRIPTION
It's not always possible to tell when you enter a logging context, this PR adds a new log to the context to make that more visible.

additionally context enter and exit logging create a lot of noise if used at various levels of your project, I dropped the logging level to debug. I would like to make this configurable at some point.